### PR TITLE
Make OpenGL dependency conditional

### DIFF
--- a/OpenAL.cabal
+++ b/OpenAL.cabal
@@ -49,6 +49,10 @@ flag BuildExamples
   description: Build various OpenAL examples.
   default: False
 
+flag UseOpenGL
+  description: Use OpenGL-provided Vertex and Vector types.
+  default: True
+
 library
   exposed-modules:
     Sound.OpenAL
@@ -87,8 +91,7 @@ library
     base         >= 3    && < 5,
     transformers >= 0.2  && < 0.6,
     ObjectName   >= 1.1  && < 1.2,
-    StateVar     >= 1.1  && < 1.3,
-    OpenGL       >= 2.12 && < 3.1
+    StateVar     >= 1.1  && < 1.3
   default-language: Haskell2010
   ghc-options: -Wall
   if impl(ghc > 8)
@@ -101,6 +104,14 @@ library
       frameworks: OpenAL
     else
       extra-libraries: openal
+  if flag(UseOpenGL)
+    build-depends:
+      OpenGL >= 2.12 && < 3.1
+    cpp-options:
+      -DUSEOPENGL
+  else
+    build-depends:
+      Tensor >= 1 && < 2
 
 executable TestDevice
   if !flag(BuildExamples)

--- a/src/Sound/OpenAL.hs
+++ b/src/Sound/OpenAL.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 --------------------------------------------------------------------------------
 -- |
 -- Module      :  Sound.OpenAL
@@ -39,7 +40,7 @@ module Sound.OpenAL (
    -- * Convenience Re-exports
    , module Data.ObjectName
    , module Data.StateVar
-   , module Graphics.Rendering.OpenGL.GL.Tensor
+   , module Tensor
 ) where
 
 import Sound.OpenAL.AL
@@ -47,7 +48,11 @@ import Sound.OpenAL.ALC
 
 import Data.ObjectName
 import Data.StateVar
-import Graphics.Rendering.OpenGL.GL.Tensor ( Vector3(..), Vertex3(..) )
+#ifdef USEOPENGL
+import Graphics.Rendering.OpenGL.GL.Tensor as Tensor ( Vector3(..), Vertex3 (..) )
+#else
+import Data.Tensor as Tensor ( Vector3(..), Vertex3 (..) )
+#endif
 
 --------------------------------------------------------------------------------
 -- $ABriefHistoryOfOpenAL

--- a/src/Sound/OpenAL/AL/Listener.hs
+++ b/src/Sound/OpenAL/AL/Listener.hs
@@ -42,7 +42,11 @@ import Foreign.Marshal.Array ( allocaArray, withArray )
 import Foreign.Marshal.Utils ( with )
 import Foreign.Ptr ( Ptr )
 import Foreign.Storable ( Storable )
+#ifdef USEOPENGL
 import Graphics.Rendering.OpenGL.GL.Tensor ( Vector3(..), Vertex3 (..) )
+#else
+import Data.Tensor ( Vector3(..), Vertex3 (..) )
+#endif
 
 import Sound.OpenAL.AL.BasicTypes
 import Sound.OpenAL.AL.PeekPoke

--- a/src/Sound/OpenAL/AL/Source.hs
+++ b/src/Sound/OpenAL/AL/Source.hs
@@ -92,7 +92,11 @@ import Foreign.Marshal.Array ( allocaArray, peekArray, withArrayLen )
 import Foreign.Marshal.Utils ( with )
 import Foreign.Ptr ( Ptr, castPtr )
 import Foreign.Storable ( Storable(..) )
-import Graphics.Rendering.OpenGL.GL.Tensor ( Vector3(..), Vertex3(..) )
+#ifdef USEOPENGL
+import Graphics.Rendering.OpenGL.GL.Tensor ( Vector3(..), Vertex3 (..) )
+#else
+import Data.Tensor ( Vector3(..), Vertex3 (..) )
+#endif
 
 import Sound.OpenAL.AL.ALboolean
 import Sound.OpenAL.AL.BasicTypes


### PR DESCRIPTION
I work with Vulkan graphics but want to use OpenAL for audio.
Bringing the whole of OpenGL with its code and library dependencies is too much when they aren't your transitives already.

Another (better) alternative would be extracting those types into OpenGL-tensor package or something and share between the two.